### PR TITLE
CSRFトークン検証ハンドラを無効化した状態で実行可能にする対応

### DIFF
--- a/サンプルプロジェクト/ソースコード/proman-project/pom.xml
+++ b/サンプルプロジェクト/ソースコード/proman-project/pom.xml
@@ -52,7 +52,7 @@
       <dependency>
         <groupId>com.nablarch.profile</groupId>
         <artifactId>nablarch-bom</artifactId>
-        <version>5u16</version>
+        <version>5u18-SNAPSHOT</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-common/src/main/java/com/nablarch/example/proman/common/handler/PassThroughHandler.java
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-common/src/main/java/com/nablarch/example/proman/common/handler/PassThroughHandler.java
@@ -1,0 +1,17 @@
+package com.nablarch.example.proman.common.handler;
+
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.Handler;
+
+/**
+ * 何もしないハンドラ。
+ * <p>
+ * 特定の環境(例えば、ローカルの開発環境)でハンドラを無効化したいときに使用する。
+ * </p>
+ */
+public class PassThroughHandler implements Handler<Object, Object> {
+    @Override
+    public Object handle(Object data, ExecutionContext context) {
+        return context.handleNext(data);
+    }
+}

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/env/dev/resources/override_dev.xml
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/env/dev/resources/override_dev.xml
@@ -11,5 +11,7 @@
   -->
   <import file="db-for-webui_dev.xml"/>
 
+  <!-- ローカル開発環境用にビルドする際にCSRFトークン検証ハンドラは不要であるため、無効化する -->
+  <component name="csrfTokenVerificationHandler" class="com.nablarch.example.proman.common.handler.PassThroughHandler" />
 
 </component-configuration>


### PR DESCRIPTION
ローカル環境で取引単体テストをする際にCSRFトークン検証ハンドラは不要であるため、設定ファイルで無効化をした