### PR TITLE
jackson-databindを2.10系の最新にバージョンアップ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,13 @@
 ### 更新内容
 #### 変更
 - サンプルプロジェクトの改善
-  - CheckStyleのバージョンを8.29にバージョンアップしました。
+  - CheckStyleのバージョンを8.29にバージョンアップしました。  
     バージョンが古く、不正なXMLを読み込ませることでXXE攻撃成立の可能性があったためです。
   - 使用しているJUnitを4.13.1に更新しました。  
     [Security fix: TemporaryFolder now limits access to temporary folders on Java 1.7 or later](https://github.com/junit-team/junit4/blob/HEAD/doc/ReleaseNotes4.13.1.md#security-fix-temporaryfolder-now-limits-access-to-temporary-folders-on-java-17-or-later) の適用のためです。
+  - jackson-databindを2.10.5.1にバージョンアップしました。  
+    [CVE-2020-25649](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-25649)対応の適用のためです。サンプルプロジェクトはCVE-2020-25649の影響を受ける機能は使用していませんが、参考にする方が誤って古いバージョンを使用しないようにするためバージョンアップをしました。
+
 ## 3.2 (2020-12-23)
 ### 更新内容
 #### 変更

--- a/en/CHANGELOG.md
+++ b/en/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All significant changes to this project will be documented in this file.
 
+## 3.3 (2021-xx-xx)
+### Updates
+#### Change
+- Improve the sample project
+  - CheckStyle version upgraded to 8.29.  
+    This was because the version was outdated and there was a possibility that an XXE attack could be launched by loading invalid XML.
+  - JUnit version upgraded to 4.13.1.  
+    This is to apply the [Security fix: TemporaryFolder now limits access to temporary folders on Java 1.7 or later](https://github.com/junit-team/junit4/blob/HEAD/doc/ReleaseNotes4.13.1.md#security-fix-temporaryfolder-now-limits-access-to-temporary-folders-on-java-17-or-later) .
+
 ## 3.2 (2020-12-23)
 ### Updates
 #### Change

--- a/en/CHANGELOG.md
+++ b/en/CHANGELOG.md
@@ -10,6 +10,8 @@ All significant changes to this project will be documented in this file.
     This was because the version was outdated and there was a possibility that an XXE attack could be launched by loading invalid XML.
   - JUnit version upgraded to 4.13.1.  
     This is to apply the [Security fix: TemporaryFolder now limits access to temporary folders on Java 1.7 or later](https://github.com/junit-team/junit4/blob/HEAD/doc/ReleaseNotes4.13.1.md#security-fix-temporaryfolder-now-limits-access-to-temporary-folders-on-java-17-or-later) .
+  - jackson-databind version upgraded to 2.10.5.1.  
+    This is to apply the [CVE-2020-25649](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-25649) issue fix. The sample project does not use any features affected by CVE-2020-25649, but upgraded it to avoid accidentally using an older version for reference.
 
 ## 3.2 (2020-12-23)
 ### Updates

--- a/en/Sample_Project/Source_Code/climan-project/pom.xml
+++ b/en/Sample_Project/Source_Code/climan-project/pom.xml
@@ -377,7 +377,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.10.3</version>
+      <version>2.10.5.1</version>
       <scope>compile</scope>
     </dependency>
 

--- a/サンプルプロジェクト/ソースコード/climan-project/pom.xml
+++ b/サンプルプロジェクト/ソースコード/climan-project/pom.xml
@@ -377,7 +377,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.10.3</version>
+      <version>2.10.5.1</version>
       <scope>compile</scope>
     </dependency>
 


### PR DESCRIPTION
## 背景
https://nablarch.atlassian.net/browse/NAB-397

## やったこと
pom.xmlに記載のjackson-databindのバージョンを現時点の最新版にバージョンアップ

## 確認したこと
日英ともに以下を確認
- ユニットテストが成功することを確認。
- climan-projectのREADME.mdに記載の動作確認を実施。