### PR TITLE
fix: ログイン時にセッションIDを再採番するだけの場合はCSRFトークンの再生成が必要なので修正

### DIFF
--- a/en/Sample_Project/Source_Code/proman-project/proman-web/src/main/java/com/nablarch/example/proman/web/login/LoginAction.java
+++ b/en/Sample_Project/Source_Code/proman-project/proman-web/src/main/java/com/nablarch/example/proman/web/login/LoginAction.java
@@ -6,6 +6,7 @@ import com.nablarch.example.proman.web.common.authentication.AuthenticationUtil;
 import com.nablarch.example.proman.web.common.authentication.context.LoginUserPrincipal;
 import com.nablarch.example.proman.web.common.authentication.exception.AuthenticationException;
 import nablarch.common.dao.UniversalDao;
+import nablarch.common.web.csrf.CsrfTokenUtil;
 import nablarch.common.web.interceptor.InjectForm;
 import nablarch.common.web.session.SessionUtil;
 import nablarch.core.message.ApplicationException;
@@ -62,6 +63,8 @@ public class LoginAction {
         // If authentication is successful, the user is redirected to the home screen
         // after the session id is changed and the authentication information is stored in the session.
         SessionUtil.changeId(context);
+        CsrfTokenUtil.regenerateCsrfToken(context);
+
         LoginUserPrincipal userContext = createLoginUserContext(form.getLoginId());
         SessionUtil.put(context, "userContext", userContext);
         return new HttpResponse(303, "redirect:///");

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/java/com/nablarch/example/proman/web/login/LoginAction.java
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/java/com/nablarch/example/proman/web/login/LoginAction.java
@@ -7,6 +7,7 @@ import com.nablarch.example.proman.web.common.authentication.AuthenticationUtil;
 import com.nablarch.example.proman.web.common.authentication.context.LoginUserPrincipal;
 import com.nablarch.example.proman.web.common.authentication.exception.AuthenticationException;
 import nablarch.common.dao.UniversalDao;
+import nablarch.common.web.csrf.CsrfTokenUtil;
 import nablarch.common.web.interceptor.InjectForm;
 import nablarch.common.web.session.SessionUtil;
 import nablarch.core.message.ApplicationException;
@@ -63,6 +64,8 @@ public class LoginAction {
         // 認証OKの場合、セッションIDを変更後、
         // 認証情報をセッションに格納後、トップ画面にリダイレクトする。
         SessionUtil.changeId(context);
+        CsrfTokenUtil.regenerateCsrfToken(context);
+
         LoginUserPrincipal userContext = createLoginUserContext(form.getLoginId());
         SessionUtil.put(context, "userContext", userContext);
         return new HttpResponse(303, "redirect:///");


### PR DESCRIPTION
[6.2.18.5. CSRFトークンの再生成を行う](https://nablarch.github.io/docs/5u20/doc/application_framework/application_framework/handlers/web/csrf_token_verification_handler.html#csrf-token-verification-handler-regeneration) にて、ログイン時にセッションIDの再生成だけを行う場合は CSRF トークンの再生成が必要であることが説明されていたので、実装を修正しました。