### PR TITLE
climan-projectでRESTfulウェブサービス用アクセスログハンドラに変更

### DIFF
--- a/en/Sample_Project/Source_Code/climan-project/pom.xml
+++ b/en/Sample_Project/Source_Code/climan-project/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.nablarch.archetype</groupId>
     <artifactId>nablarch-archetype-parent</artifactId>
-    <version>5u21</version>
+    <version>5-NEXT-SNAPSHOT</version>
   </parent>
 
   <groupId>com.nablarch.example.climan</groupId>
@@ -275,7 +275,7 @@
       <dependency>
         <groupId>com.nablarch.profile</groupId>
         <artifactId>nablarch-bom</artifactId>
-        <version>5u21</version>
+        <version>5-NEXT-SNAPSHOT</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/en/Sample_Project/Source_Code/climan-project/src/env/dev/resources/handler_dev.xml
+++ b/en/Sample_Project/Source_Code/climan-project/src/env/dev/resources/handler_dev.xml
@@ -21,7 +21,7 @@
         <component-ref name="threadContextHandler"/>
 
         <!-- add -->
-        <component class="nablarch.common.web.handler.HttpAccessLogHandler"/>
+        <component class="nablarch.fw.jaxrs.JaxRsAccessLogHandler"/>
 
         <component-ref name="dbConnectionManagementHandler"/>
 

--- a/en/Sample_Project/Source_Code/climan-project/src/main/resources/app-log.properties
+++ b/en/Sample_Project/Source_Code/climan-project/src/main/resources/app-log.properties
@@ -8,31 +8,31 @@ failureLogFormatter.analysisFormat=fail_code = [$failureCode$] $message$\nInput 
 #failureLogFormatter.contactFilePath=
 #failureLogFormatter.fwFailureCodeFilePath=
 
-# HttpAccessLogFormatter
-#httpAccessLogFormatter.className=
-#httpAccessLogFormatter.datePattern=
-#httpAccessLogFormatter.maskingChar=
-#httpAccessLogFormatter.maskingPatterns=
-#httpAccessLogFormatter.parametersSeparator=
-#httpAccessLogFormatter.sessionScopeSeparator=
-#httpAccessLogFormatter.beginOutputEnabled=
-#httpAccessLogFormatter.parametersOutputEnabled=
-#httpAccessLogFormatter.dispatchingClassOutputEnabled=
-#httpAccessLogFormatter.endOutputEnabled=
-httpAccessLogFormatter.beginFormat=@@@@ BEGIN @@@@ rid = [$requestId$] uid = [$userId$] sid = [$sessionId$]\
+# JaxRsAccessLogFormatter
+#jaxRsAccessLogFormatter.className=
+#jaxRsAccessLogFormatter.datePattern=
+#jaxRsAccessLogFormatter.maskingChar=
+#jaxRsAccessLogFormatter.maskingPatterns=
+#jaxRsAccessLogFormatter.bodyLogTargetMatcher=
+#jaxRsAccessLogFormatter.bodyMaskingFilter=
+#jaxRsAccessLogFormatter.bodyMaskingItemNames=
+#jaxRsAccessLogFormatter.parametersSeparator=
+#jaxRsAccessLogFormatter.sessionScopeSeparator=
+#jaxRsAccessLogFormatter.beginOutputEnabled=
+#jaxRsAccessLogFormatter.endOutputEnabled=
+jaxRsAccessLogFormatter.beginFormat=@@@@ BEGIN @@@@ rid = [$requestId$] uid = [$userId$] sid = [$sessionId$]\
                                       \n\turl         = [$url$$query$]\
                                       \n\tmethod      = [$method$]\
                                       \n\tport        = [$port$]\
                                       \n\tclient_ip   = [$clientIpAddress$]\
                                       \n\tclient_host = [$clientHost$]
-httpAccessLogFormatter.parametersFormat=@@@@ PARAMETERS @@@@\n\tparameters  = [$parameters$]
-httpAccessLogFormatter.dispatchingClassFormat=@@@@ DISPATCHING CLASS @@@@ class = [$dispatchingClass$]
-httpAccessLogFormatter.endFormat=@@@@ END @@@@ rid = [$requestId$] uid = [$userId$] sid = [$sessionId$] url = [$url$$query$] method = [$method$] status_code = [$statusCode$] content_path = [$contentPath$]\
+jaxRsAccessLogFormatter.endFormat=@@@@ END @@@@ rid = [$requestId$] uid = [$userId$] sid = [$sessionId$] url = [$url$$query$] method = [$method$] status_code = [$statusCode$]\
                                     \n\tstart_time     = [$startTime$]\
                                     \n\tend_time       = [$endTime$]\
                                     \n\texecution_time = [$executionTime$]\
                                     \n\tmax_memory     = [$maxMemory$]\
                                     \n\tfree_memory    = [$freeMemory$]
+
 
 # MessagingLogFormatter
 #messagingLogFormatter.className=

--- a/en/Sample_Project/Source_Code/climan-project/src/main/resources/rest-component-configuration.xml
+++ b/en/Sample_Project/Source_Code/climan-project/src/main/resources/rest-component-configuration.xml
@@ -101,7 +101,7 @@
         <component-ref name="threadContextHandler"/>
 
         <!-- add -->
-        <component class="nablarch.common.web.handler.HttpAccessLogHandler"/>
+        <component class="nablarch.fw.jaxrs.JaxRsAccessLogHandler"/>
 
         <component-ref name="dbConnectionManagementHandler"/>
 

--- a/en/Sample_Project/Source_Code/climan-project/src/test/java/com/nablarch/example/climan/rest/common/dao/DaoStub.java
+++ b/en/Sample_Project/Source_Code/climan-project/src/test/java/com/nablarch/example/climan/rest/common/dao/DaoStub.java
@@ -18,6 +18,11 @@ public class DaoStub implements DaoContext {
     }
 
     @Override
+    public <T> T findByIdOrNull(Class<T> entityClass, Object... id) {
+        return null;
+    }
+
+    @Override
     public <T> EntityList<T> findAll(Class<T> entityClass) {
         return null;
     }
@@ -34,6 +39,11 @@ public class DaoStub implements DaoContext {
 
     @Override
     public <T> T findBySqlFile(Class<T> entityClass, String sqlId, Object params) {
+        return null;
+    }
+
+    @Override
+    public <T> T findBySqlFileOrNull(Class<T> entityClass, String sqlId, Object params) {
         return null;
     }
 

--- a/サンプルプロジェクト/ソースコード/climan-project/pom.xml
+++ b/サンプルプロジェクト/ソースコード/climan-project/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.nablarch.archetype</groupId>
     <artifactId>nablarch-archetype-parent</artifactId>
-    <version>5u21</version>
+    <version>5-NEXT-SNAPSHOT</version>
   </parent>
 
   <groupId>com.nablarch.example.climan</groupId>
@@ -275,7 +275,7 @@
       <dependency>
         <groupId>com.nablarch.profile</groupId>
         <artifactId>nablarch-bom</artifactId>
-        <version>5u21</version>
+        <version>5-NEXT-SNAPSHOT</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/サンプルプロジェクト/ソースコード/climan-project/src/env/dev/resources/handler_dev.xml
+++ b/サンプルプロジェクト/ソースコード/climan-project/src/env/dev/resources/handler_dev.xml
@@ -21,7 +21,7 @@
         <component-ref name="threadContextHandler"/>
 
         <!-- 追加 -->
-        <component class="nablarch.common.web.handler.HttpAccessLogHandler"/>
+        <component class="nablarch.fw.jaxrs.JaxRsAccessLogHandler"/>
 
         <component-ref name="dbConnectionManagementHandler"/>
 

--- a/サンプルプロジェクト/ソースコード/climan-project/src/main/resources/app-log.properties
+++ b/サンプルプロジェクト/ソースコード/climan-project/src/main/resources/app-log.properties
@@ -8,26 +8,25 @@ failureLogFormatter.analysisFormat=fail_code = [$failureCode$] $message$\nInput 
 #failureLogFormatter.contactFilePath=
 #failureLogFormatter.fwFailureCodeFilePath=
 
-# HttpAccessLogFormatter
-#httpAccessLogFormatter.className=
-#httpAccessLogFormatter.datePattern=
-#httpAccessLogFormatter.maskingChar=
-#httpAccessLogFormatter.maskingPatterns=
-#httpAccessLogFormatter.parametersSeparator=
-#httpAccessLogFormatter.sessionScopeSeparator=
-#httpAccessLogFormatter.beginOutputEnabled=
-#httpAccessLogFormatter.parametersOutputEnabled=
-#httpAccessLogFormatter.dispatchingClassOutputEnabled=
-#httpAccessLogFormatter.endOutputEnabled=
-httpAccessLogFormatter.beginFormat=@@@@ BEGIN @@@@ rid = [$requestId$] uid = [$userId$] sid = [$sessionId$]\
+# JaxRsAccessLogFormatter
+#jaxRsAccessLogFormatter.className=
+#jaxRsAccessLogFormatter.datePattern=
+#jaxRsAccessLogFormatter.maskingChar=
+#jaxRsAccessLogFormatter.maskingPatterns=
+#jaxRsAccessLogFormatter.bodyLogTargetMatcher=
+#jaxRsAccessLogFormatter.bodyMaskingFilter=
+#jaxRsAccessLogFormatter.bodyMaskingItemNames=
+#jaxRsAccessLogFormatter.parametersSeparator=
+#jaxRsAccessLogFormatter.sessionScopeSeparator=
+#jaxRsAccessLogFormatter.beginOutputEnabled=
+#jaxRsAccessLogFormatter.endOutputEnabled=
+jaxRsAccessLogFormatter.beginFormat=@@@@ BEGIN @@@@ rid = [$requestId$] uid = [$userId$] sid = [$sessionId$]\
                                       \n\turl         = [$url$$query$]\
                                       \n\tmethod      = [$method$]\
                                       \n\tport        = [$port$]\
                                       \n\tclient_ip   = [$clientIpAddress$]\
                                       \n\tclient_host = [$clientHost$]
-httpAccessLogFormatter.parametersFormat=@@@@ PARAMETERS @@@@\n\tparameters  = [$parameters$]
-httpAccessLogFormatter.dispatchingClassFormat=@@@@ DISPATCHING CLASS @@@@ class = [$dispatchingClass$]
-httpAccessLogFormatter.endFormat=@@@@ END @@@@ rid = [$requestId$] uid = [$userId$] sid = [$sessionId$] url = [$url$$query$] method = [$method$] status_code = [$statusCode$] content_path = [$contentPath$]\
+jaxRsAccessLogFormatter.endFormat=@@@@ END @@@@ rid = [$requestId$] uid = [$userId$] sid = [$sessionId$] url = [$url$$query$] method = [$method$] status_code = [$statusCode$]\
                                     \n\tstart_time     = [$startTime$]\
                                     \n\tend_time       = [$endTime$]\
                                     \n\texecution_time = [$executionTime$]\

--- a/サンプルプロジェクト/ソースコード/climan-project/src/main/resources/rest-component-configuration.xml
+++ b/サンプルプロジェクト/ソースコード/climan-project/src/main/resources/rest-component-configuration.xml
@@ -88,7 +88,7 @@
         <component-ref name="threadContextHandler"/>
 
         <!-- 追加 -->
-        <component class="nablarch.common.web.handler.HttpAccessLogHandler"/>
+        <component class="nablarch.fw.jaxrs.JaxRsAccessLogHandler"/>
 
         <component-ref name="dbConnectionManagementHandler"/>
 

--- a/サンプルプロジェクト/ソースコード/climan-project/src/test/java/com/nablarch/example/climan/rest/common/dao/DaoStub.java
+++ b/サンプルプロジェクト/ソースコード/climan-project/src/test/java/com/nablarch/example/climan/rest/common/dao/DaoStub.java
@@ -18,6 +18,11 @@ public class DaoStub implements DaoContext {
     }
 
     @Override
+    public <T> T findByIdOrNull(Class<T> entityClass, Object... id) {
+        return null;
+    }
+
+    @Override
     public <T> EntityList<T> findAll(Class<T> entityClass) {
         return null;
     }
@@ -34,6 +39,11 @@ public class DaoStub implements DaoContext {
 
     @Override
     public <T> T findBySqlFile(Class<T> entityClass, String sqlId, Object params) {
+        return null;
+    }
+
+    @Override
+    public <T> T findBySqlFileOrNull(Class<T> entityClass, String sqlId, Object params) {
         return null;
     }
 


### PR DESCRIPTION
RESTfulウェブサービス用アクセスログハンドラを使用するためにはNablarchのバージョンを `5-NEXT-SNAPSHOT` に上げる必要があったため、合わせて対応しています。