### PR TITLE
proman-projectのNablarchをv6に上げる（web）

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,1 @@
+--add-opens java.base/java.lang=ALL-UNNAMED

--- a/en/Sample_Project/Source_Code/proman-project/proman-web/src/main/webapp/WEB-INF/web.xml
+++ b/en/Sample_Project/Source_Code/proman-project/proman-web/src/main/webapp/WEB-INF/web.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee" 
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee 
-         http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd" 
-         version="3.1">
+<web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
+                             web-app_6_0.xsd"
+         version="6.0">
   <context-param>
     <!-- DI container settings file path -->
     <param-name>di.config</param-name>

--- a/en/Sample_Project/Source_Code/proman-project/proman-web/src/test/resources/unit-test.xml
+++ b/en/Sample_Project/Source_Code/proman-project/proman-web/src/test/resources/unit-test.xml
@@ -7,6 +7,6 @@
   <!-- Main settings -->
   <import file="web-component-configuration.xml"/>
 
-  <!-- Define Jetty6 as a test HttpServer -->
-  <component name="httpServerFactory" class="nablarch.fw.web.httpserver.HttpServerFactoryJetty6"/>
+  <!-- Define Jetty9 as a test HttpServer -->
+  <component name="httpServerFactory" class="nablarch.fw.web.httpserver.HttpServerFactoryJetty9"/>
 </component-configuration>

--- a/en/Sample_Project/Source_Code/proman-project/proman-web/src/test/resources/unit-test.xml
+++ b/en/Sample_Project/Source_Code/proman-project/proman-web/src/test/resources/unit-test.xml
@@ -7,6 +7,6 @@
   <!-- Main settings -->
   <import file="web-component-configuration.xml"/>
 
-  <!-- Define Jetty9 as a test HttpServer -->
-  <component name="httpServerFactory" class="nablarch.fw.web.httpserver.HttpServerFactoryJetty9"/>
+  <!-- Define Jetty12 as a test HttpServer -->
+  <component name="httpServerFactory" class="nablarch.fw.web.httpserver.HttpServerFactoryJetty12"/>
 </component-configuration>

--- a/サンプルプロジェクト/ソースコード/climan-project/src/test/resources/unit-test.xml
+++ b/サンプルプロジェクト/ソースコード/climan-project/src/test/resources/unit-test.xml
@@ -28,7 +28,7 @@
     <property name="schema" value="${nablarch.db.schema}"/>
   </component>
 
-  <!-- テスト用HttpServerにJetty6を定義する -->
-  <component name="httpServerFactory" class="nablarch.fw.web.httpserver.HttpServerFactoryJetty6"/>
+  <!-- テスト用HttpServerにJetty9を定義する -->
+  <component name="httpServerFactory" class="nablarch.fw.web.httpserver.HttpServerFactoryJetty9"/>
 
 </component-configuration>

--- a/サンプルプロジェクト/ソースコード/climan-project/src/test/resources/unit-test.xml
+++ b/サンプルプロジェクト/ソースコード/climan-project/src/test/resources/unit-test.xml
@@ -28,7 +28,7 @@
     <property name="schema" value="${nablarch.db.schema}"/>
   </component>
 
-  <!-- テスト用HttpServerにJetty9を定義する -->
-  <component name="httpServerFactory" class="nablarch.fw.web.httpserver.HttpServerFactoryJetty9"/>
+  <!-- テスト用HttpServerにJetty6を定義する -->
+  <component name="httpServerFactory" class="nablarch.fw.web.httpserver.HttpServerFactoryJetty6"/>
 
 </component-configuration>

--- a/サンプルプロジェクト/ソースコード/proman-project/pom.xml
+++ b/サンプルプロジェクト/ソースコード/proman-project/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.nablarch.archetype</groupId>
     <artifactId>nablarch-archetype-parent</artifactId>
-    <version>5-NEXT-SNAPSHOT</version>
+    <version>6-NEXT-SNAPSHOT</version>
     <relativePath/>
   </parent>
 
@@ -54,7 +54,15 @@
       <dependency>
         <groupId>com.nablarch.profile</groupId>
         <artifactId>nablarch-bom</artifactId>
-        <version>5-NEXT-SNAPSHOT</version>
+        <version>6-NEXT-SNAPSHOT</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <!-- Jakarta EE -->
+      <dependency>
+        <groupId>jakarta.platform</groupId>
+        <artifactId>jakarta.jakartaee-bom</artifactId>
+        <version>10.0.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-common/pom.xml
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-common/pom.xml
@@ -15,7 +15,7 @@
 
   <properties>
     <nablarch.db.jdbcDriver>org.postgresql.Driver</nablarch.db.jdbcDriver>
-    <nablarch.db.url>jdbc:postgresql://localhost:5432/postgres</nablarch.db.url>
+    <nablarch.db.url>jdbc:postgresql://localhost:5433/postgres</nablarch.db.url>
     <nablarch.db.adminUser>postgres</nablarch.db.adminUser>
     <nablarch.db.adminPassword>password</nablarch.db.adminPassword>
     <nablarch.db.user>postgres</nablarch.db.user>
@@ -52,14 +52,13 @@
     </dependency>
 
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator</artifactId>
-      <version>5.1.3.Final</version>
+      <version>8.0.0.Final</version>
     </dependency>
     <dependency>
-      <groupId>org.glassfish</groupId>
-      <artifactId>javax.el</artifactId>
-      <version>3.0.0</version>
+      <groupId>jakarta.el</groupId>
+      <artifactId>jakarta.el-api</artifactId>
     </dependency>
 
     <dependency>
@@ -70,24 +69,16 @@
 
     <!-- Java17を使用するためのセットアップ -->
     <dependency>
-      <groupId>com.sun.activation</groupId>
-      <artifactId>javax.activation</artifactId>
-      <version>1.2.0</version>
+      <groupId>jakarta.activation</groupId>
+      <artifactId>jakarta.activation-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.sun.xml.bind</groupId>
-      <artifactId>jaxb-core</artifactId>
-      <version>2.3.0</version>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.sun.xml.bind</groupId>
-      <artifactId>jaxb-impl</artifactId>
-      <version>2.3.5</version>
-    </dependency>
-    <dependency>
-      <groupId>javax.annotation</groupId>
-      <artifactId>javax.annotation-api</artifactId>
-      <version>1.3.2</version>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
     </dependency>
 
   </dependencies>
@@ -132,27 +123,6 @@
               <groupId>org.postgresql</groupId>
               <artifactId>postgresql</artifactId>
               <version>${postgres.jdbc.driver.version}</version>
-            </dependency>
-            <!-- Java17を使用するためのセットアップ -->
-            <dependency>
-              <groupId>javax.activation</groupId>
-              <artifactId>javax.activation-api</artifactId>
-              <version>1.2.0</version>
-            </dependency>
-            <dependency>
-              <groupId>com.sun.xml.bind</groupId>
-              <artifactId>jaxb-core</artifactId>
-              <version>2.3.0</version>
-            </dependency>
-            <dependency>
-              <groupId>com.sun.xml.bind</groupId>
-              <artifactId>jaxb-impl</artifactId>
-              <version>2.3.5</version>
-            </dependency>
-            <dependency>
-              <groupId>javax.annotation</groupId>
-              <artifactId>javax.annotation-api</artifactId>
-              <version>1.3.2</version>
             </dependency>
           </dependencies>
           <configuration>

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-common/pom.xml
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-common/pom.xml
@@ -68,6 +68,27 @@
       <scope>runtime</scope>
     </dependency>
 
+    <!-- Java17を使用するためのセットアップ -->
+    <dependency>
+      <groupId>com.sun.activation</groupId>
+      <artifactId>javax.activation</artifactId>
+      <version>1.2.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-core</artifactId>
+      <version>2.3.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+      <version>2.3.5</version>
+    </dependency>
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+      <version>1.3.2</version>
+    </dependency>
 
   </dependencies>
 
@@ -111,6 +132,27 @@
               <groupId>org.postgresql</groupId>
               <artifactId>postgresql</artifactId>
               <version>${postgres.jdbc.driver.version}</version>
+            </dependency>
+            <!-- Java17を使用するためのセットアップ -->
+            <dependency>
+              <groupId>javax.activation</groupId>
+              <artifactId>javax.activation-api</artifactId>
+              <version>1.2.0</version>
+            </dependency>
+            <dependency>
+              <groupId>com.sun.xml.bind</groupId>
+              <artifactId>jaxb-core</artifactId>
+              <version>2.3.0</version>
+            </dependency>
+            <dependency>
+              <groupId>com.sun.xml.bind</groupId>
+              <artifactId>jaxb-impl</artifactId>
+              <version>2.3.5</version>
+            </dependency>
+            <dependency>
+              <groupId>javax.annotation</groupId>
+              <artifactId>javax.annotation-api</artifactId>
+              <version>1.3.2</version>
             </dependency>
           </dependencies>
           <configuration>

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-common/pom.xml
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-common/pom.xml
@@ -15,7 +15,7 @@
 
   <properties>
     <nablarch.db.jdbcDriver>org.postgresql.Driver</nablarch.db.jdbcDriver>
-    <nablarch.db.url>jdbc:postgresql://localhost:5433/postgres</nablarch.db.url>
+    <nablarch.db.url>jdbc:postgresql://localhost:5432/postgres</nablarch.db.url>
     <nablarch.db.adminUser>postgres</nablarch.db.adminUser>
     <nablarch.db.adminPassword>password</nablarch.db.adminPassword>
     <nablarch.db.user>postgres</nablarch.db.user>

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-common/pom.xml
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-common/pom.xml
@@ -67,7 +67,6 @@
       <scope>runtime</scope>
     </dependency>
 
-    <!-- Java17を使用するためのセットアップ -->
     <dependency>
       <groupId>jakarta.activation</groupId>
       <artifactId>jakarta.activation-api</artifactId>

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-common/src/main/java/com/nablarch/example/proman/common/validation/MoneyRange.java
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-common/src/main/java/com/nablarch/example/proman/common/validation/MoneyRange.java
@@ -1,8 +1,8 @@
 package com.nablarch.example.proman.common.validation;
 
 
-import javax.validation.Constraint;
-import javax.validation.Payload;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-common/src/main/java/com/nablarch/example/proman/common/validation/MoneyRangeValidator.java
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-common/src/main/java/com/nablarch/example/proman/common/validation/MoneyRangeValidator.java
@@ -2,8 +2,8 @@ package com.nablarch.example.proman.common.validation;
 
 import nablarch.core.util.StringUtil;
 
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
 
 /**
  * 指定された整数の範囲の金額であることを検証するバリデータ。

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-web/pom.xml
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-web/pom.xml
@@ -64,9 +64,8 @@
           <artifactId>HikariCP</artifactId>
         </dependency>
         <dependency>
-          <groupId>javax.servlet</groupId>
-          <artifactId>jstl</artifactId>
-          <version>1.2</version>
+          <groupId>jakarta.servlet</groupId>
+          <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
       </dependencies>
     </profile>
@@ -106,8 +105,8 @@
       <artifactId>nablarch-web</artifactId>
       <exclusions>
         <exclusion>
-          <groupId>taglibs</groupId>
-          <artifactId>standard</artifactId>
+          <groupId>org.glassfish.web</groupId>
+          <artifactId>jakarta.servlet.jsp.jstl</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -130,7 +129,7 @@
     </dependency>
     <dependency>
       <groupId>com.nablarch.framework</groupId>
-      <artifactId>nablarch-testing-jetty6</artifactId>
+      <artifactId>nablarch-testing-jetty12</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -141,7 +140,7 @@
     <dependency>
       <groupId>com.nablarch.dev</groupId>
       <artifactId>nablarch-test-support</artifactId>
-      <version>0.1.0</version>
+      <version>2.0.0</version>
       <scope>test</scope>
     </dependency>
 
@@ -166,22 +165,20 @@
     </dependency>
 
     <dependency>
-      <groupId>javax.servlet.jsp</groupId>
-      <artifactId>javax.servlet.jsp-api</artifactId>
-      <version>2.3.1</version>
+      <groupId>jakarta.servlet.jsp</groupId>
+      <artifactId>jakarta.servlet.jsp-api</artifactId>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
-      <groupId>javax.servlet.jsp.jstl</groupId>
-      <artifactId>javax.servlet.jsp.jstl-api</artifactId>
-      <version>1.2.1</version>
+      <groupId>jakarta.servlet.jsp.jstl</groupId>
+      <artifactId>jakarta.servlet.jsp.jstl-api</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator</artifactId>
-      <version>5.1.3.Final</version>
+      <version>8.0.0.Final</version>
     </dependency>
 
     <dependency>
@@ -200,6 +197,20 @@
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
+    </dependency>
+
+    <!-- Java17を使用するためのセットアップ -->
+    <dependency>
+      <groupId>jakarta.activation</groupId>
+      <artifactId>jakarta.activation-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
     </dependency>
   </dependencies>
 
@@ -223,19 +234,9 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>net.unit8.waitt</groupId>
-        <artifactId>waitt-maven-plugin</artifactId>
-        <version>1.2.3</version>
-        <configuration>
-          <port>9080</port>
-          <servers>
-            <server>
-              <groupId>net.unit8.waitt.server</groupId>
-              <artifactId>waitt-tomcat8</artifactId>
-              <version>1.2.3</version>
-            </server>
-          </servers>
-        </configuration>
+        <groupId>org.eclipse.jetty.ee10</groupId>
+        <artifactId>jetty-ee10-maven-plugin</artifactId>
+        <version>12.0.3</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-web/pom.xml
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-web/pom.xml
@@ -199,7 +199,6 @@
       <scope>test</scope>
     </dependency>
 
-    <!-- Java17を使用するためのセットアップ -->
     <dependency>
       <groupId>jakarta.activation</groupId>
       <artifactId>jakarta.activation-api</artifactId>

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/java/com/nablarch/example/proman/web/common/handler/PromanErrorForwardHandler.java
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/java/com/nablarch/example/proman/web/common/handler/PromanErrorForwardHandler.java
@@ -7,7 +7,7 @@ import nablarch.fw.Handler;
 import nablarch.fw.web.HttpErrorResponse;
 import nablarch.fw.web.HttpResponse.Status;
 
-import javax.persistence.OptimisticLockException;
+import jakarta.persistence.OptimisticLockException;
 
 /**
  * 特定の例外が送出された場合に、適切なエラー画面に遷移させるハンドラ。

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/java/com/nablarch/example/proman/web/common/validation/FormBinder.java
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/java/com/nablarch/example/proman/web/common/validation/FormBinder.java
@@ -174,6 +174,11 @@ public class FormBinder<T extends Serializable> {
             public String validate() {
                 return "";  // 使用しない。
             }
+
+            @Override
+            public Class<?>[] validationGroup() {
+                return new Class<?>[0];  // 使用しない。 }
+            }
         };
     }
 

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/java/com/nablarch/example/proman/web/project/ProjectCreateForm.java
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/java/com/nablarch/example/proman/web/project/ProjectCreateForm.java
@@ -4,7 +4,7 @@ import com.nablarch.example.proman.common.util.DateRelationUtil;
 import nablarch.core.validation.ee.Domain;
 import nablarch.core.validation.ee.Required;
 
-import javax.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.AssertTrue;
 import java.io.Serializable;
 
 /**

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/java/com/nablarch/example/proman/web/project/ProjectSearchForm.java
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/java/com/nablarch/example/proman/web/project/ProjectSearchForm.java
@@ -6,8 +6,8 @@ import com.nablarch.example.proman.web.common.SearchFormBase;
 import nablarch.core.util.StringUtil;
 import nablarch.core.validation.ee.Domain;
 
-import javax.validation.Valid;
-import javax.validation.constraints.AssertTrue;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.AssertTrue;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/java/com/nablarch/example/proman/web/project/ProjectUpdateForm.java
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/java/com/nablarch/example/proman/web/project/ProjectUpdateForm.java
@@ -4,7 +4,7 @@ import com.nablarch.example.proman.common.util.DateRelationUtil;
 import nablarch.core.validation.ee.Domain;
 import nablarch.core.validation.ee.Required;
 
-import javax.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.AssertTrue;
 import java.io.Serializable;
 
 /**

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/webapp/WEB-INF/tags/listSearchResult/listSearchPaging.tag
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/webapp/WEB-INF/tags/listSearchResult/listSearchPaging.tag
@@ -3,7 +3,7 @@
 --------------------------------------------------------------%>
 <%@ tag language="java" pageEncoding="UTF-8" %>
 <%@ taglib prefix="n" uri="http://tis.co.jp/nablarch" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="lsr" tagdir="/WEB-INF/tags/listSearchResult" %>
 
 <%--------------------------------------------------------------

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/webapp/WEB-INF/tags/listSearchResult/listSearchResult.tag
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/webapp/WEB-INF/tags/listSearchResult/listSearchResult.tag
@@ -3,7 +3,7 @@
 --------------------------------------------------------------%>
 <%@ tag language="java" pageEncoding="UTF-8" %>
 <%@ taglib prefix="n" uri="http://tis.co.jp/nablarch" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="lsr" tagdir="/WEB-INF/tags/listSearchResult" %>
 
 <%--------------------------------------------------------------

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/webapp/WEB-INF/tags/listSearchResult/listSearchSubmit.tag
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/webapp/WEB-INF/tags/listSearchResult/listSearchSubmit.tag
@@ -3,7 +3,7 @@
 --------------------------------------------------------------%>
 <%@ tag language="java" pageEncoding="UTF-8" %>
 <%@ taglib prefix="n" uri="http://tis.co.jp/nablarch" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="app" tagdir="/WEB-INF/tags/listSearchResult" %>
 <%--------------------------------------------------------------
 属性

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/webapp/WEB-INF/tags/listSearchResult/table.tag
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/webapp/WEB-INF/tags/listSearchResult/table.tag
@@ -3,7 +3,7 @@
 --------------------------------------------------------------%>
 <%@ tag language="java" pageEncoding="UTF-8" %>
 <%@ taglib prefix="n" uri="http://tis.co.jp/nablarch" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="app" tagdir="/WEB-INF/tags/listSearchResult" %>
 <%--------------------------------------------------------------
 属性

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/webapp/WEB-INF/view/common/footer.jsp
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/webapp/WEB-INF/view/common/footer.jsp
@@ -1,5 +1,5 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="n" uri="http://tis.co.jp/nablarch" %>
 <%@ page session="false" %>
 

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/webapp/WEB-INF/view/common/header.jsp
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/webapp/WEB-INF/view/common/header.jsp
@@ -1,5 +1,5 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="n" uri="http://tis.co.jp/nablarch" %>
 <%@ page session="false" %>
 

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/webapp/WEB-INF/view/common/menu.jsp
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/webapp/WEB-INF/view/common/menu.jsp
@@ -1,5 +1,5 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="n" uri="http://tis.co.jp/nablarch" %>
 <%@ page session="false" %>
 

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/webapp/WEB-INF/view/common/noscript.jsp
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/webapp/WEB-INF/view/common/noscript.jsp
@@ -1,5 +1,5 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="n" uri="http://tis.co.jp/nablarch" %>
 <%@ page session="false" %>
 

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/webapp/WEB-INF/view/common/topMenu.jsp
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/webapp/WEB-INF/view/common/topMenu.jsp
@@ -1,4 +1,4 @@
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="n" uri="http://tis.co.jp/nablarch" %>
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 <%@ page session="true" %>

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/webapp/WEB-INF/view/errorPages/DOUBLE_SUBMISSION_ERROR.jsp
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/webapp/WEB-INF/view/errorPages/DOUBLE_SUBMISSION_ERROR.jsp
@@ -1,4 +1,4 @@
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="n" uri="http://tis.co.jp/nablarch" %>
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 <!DOCTYPE html>

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/webapp/WEB-INF/view/errorPages/ERROR.jsp
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/webapp/WEB-INF/view/errorPages/ERROR.jsp
@@ -1,4 +1,4 @@
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="n" uri="http://tis.co.jp/nablarch" %>
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 <!DOCTYPE html>

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/webapp/WEB-INF/view/errorPages/OPTIMISTIC_LOCK_ERROR.jsp
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/webapp/WEB-INF/view/errorPages/OPTIMISTIC_LOCK_ERROR.jsp
@@ -1,4 +1,4 @@
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="n" uri="http://tis.co.jp/nablarch" %>
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 <!DOCTYPE html>

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/webapp/WEB-INF/view/errorPages/PAGE_NOT_FOUND_ERROR.jsp
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/webapp/WEB-INF/view/errorPages/PAGE_NOT_FOUND_ERROR.jsp
@@ -1,4 +1,4 @@
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="n" uri="http://tis.co.jp/nablarch" %>
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 <!DOCTYPE html>

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/webapp/WEB-INF/view/errorPages/PERMISSION-ERROR.jsp
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/webapp/WEB-INF/view/errorPages/PERMISSION-ERROR.jsp
@@ -1,4 +1,4 @@
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="n" uri="http://tis.co.jp/nablarch" %>
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 <!DOCTYPE html>

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/webapp/WEB-INF/view/errorPages/REQUEST_ENTITY_TOO_LARGE.jsp
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/webapp/WEB-INF/view/errorPages/REQUEST_ENTITY_TOO_LARGE.jsp
@@ -1,4 +1,4 @@
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="n" uri="http://tis.co.jp/nablarch" %>
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 <!DOCTYPE html>

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/webapp/WEB-INF/view/errorPages/SERVICE-UNAVAILABLE-ERROR.jsp
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/webapp/WEB-INF/view/errorPages/SERVICE-UNAVAILABLE-ERROR.jsp
@@ -1,4 +1,4 @@
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="n" uri="http://tis.co.jp/nablarch" %>
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 <!DOCTYPE html>

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/webapp/WEB-INF/view/errorPages/SESSION_KEY_NOT_FOUND_ERROR.jsp
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/webapp/WEB-INF/view/errorPages/SESSION_KEY_NOT_FOUND_ERROR.jsp
@@ -1,4 +1,4 @@
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="n" uri="http://tis.co.jp/nablarch" %>
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 <!DOCTYPE html>

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/webapp/WEB-INF/view/errorPages/TAMPERING-DETECTED.jsp
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/webapp/WEB-INF/view/errorPages/TAMPERING-DETECTED.jsp
@@ -1,4 +1,4 @@
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="n" uri="http://tis.co.jp/nablarch" %>
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 <!DOCTYPE html>

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/webapp/WEB-INF/view/errorPages/USER_ERROR.jsp
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/webapp/WEB-INF/view/errorPages/USER_ERROR.jsp
@@ -1,4 +1,4 @@
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="n" uri="http://tis.co.jp/nablarch" %>
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 <!DOCTYPE html>

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/webapp/WEB-INF/view/login/login.jsp
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/webapp/WEB-INF/view/login/login.jsp
@@ -1,5 +1,5 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="n" uri="http://tis.co.jp/nablarch" %>
 <%@ page session="false" %>
 

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/webapp/WEB-INF/view/project/completionOfCreation.jsp
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/webapp/WEB-INF/view/project/completionOfCreation.jsp
@@ -1,5 +1,5 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="n" uri="http://tis.co.jp/nablarch" %>
 <%@ page session="false" %>
 

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/webapp/WEB-INF/view/project/completionOfUpdate.jsp
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/webapp/WEB-INF/view/project/completionOfUpdate.jsp
@@ -1,5 +1,5 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="n" uri="http://tis.co.jp/nablarch" %>
 <%@ page session="false" %>
 

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/webapp/WEB-INF/view/project/confirmationOfCreation.jsp
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/webapp/WEB-INF/view/project/confirmationOfCreation.jsp
@@ -1,5 +1,5 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="n" uri="http://tis.co.jp/nablarch" %>
 <%@ page session="false" %>
 <n:confirmationPage path="./create.jsp" ></n:confirmationPage>

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/webapp/WEB-INF/view/project/confirmationOfUpdate.jsp
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/webapp/WEB-INF/view/project/confirmationOfUpdate.jsp
@@ -1,5 +1,5 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="n" uri="http://tis.co.jp/nablarch" %>
 <%@ page session="false" %>
 <n:confirmationPage path="./update.jsp" ></n:confirmationPage>

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/webapp/WEB-INF/view/project/create.jsp
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/webapp/WEB-INF/view/project/create.jsp
@@ -1,5 +1,5 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="n" uri="http://tis.co.jp/nablarch" %>
 <%@ page session="false" %>
 

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/webapp/WEB-INF/view/project/detail.jsp
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/webapp/WEB-INF/view/project/detail.jsp
@@ -1,4 +1,4 @@
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="n" uri="http://tis.co.jp/nablarch" %>
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 <!DOCTYPE html>

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/webapp/WEB-INF/view/project/search.jsp
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/webapp/WEB-INF/view/project/search.jsp
@@ -1,4 +1,4 @@
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="n" uri="http://tis.co.jp/nablarch" %>
 <%@ taglib prefix="lsr" tagdir="/WEB-INF/tags/listSearchResult" %>
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/webapp/WEB-INF/view/project/update.jsp
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/webapp/WEB-INF/view/project/update.jsp
@@ -1,5 +1,5 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="n" uri="http://tis.co.jp/nablarch" %>
 <%@ page session="false" %>
 

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/webapp/WEB-INF/web.xml
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/webapp/WEB-INF/web.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee" 
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee 
-         http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd" 
-         version="3.1">
+<web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
+                             web-app_6_0.xsd"
+         version="6.0">
   <context-param>
     <!-- DIコンテナの設定ファイルパス -->
     <param-name>di.config</param-name>

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/test/java/com/nablarch/example/proman/web/common/dao/DaoStub.java
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/test/java/com/nablarch/example/proman/web/common/dao/DaoStub.java
@@ -3,7 +3,7 @@ package com.nablarch.example.proman.web.common.dao;
 import nablarch.common.dao.DaoContext;
 import nablarch.common.dao.EntityList;
 
-import javax.persistence.OptimisticLockException;
+import jakarta.persistence.OptimisticLockException;
 import java.util.List;
 
 /**

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/test/resources/unit-test.xml
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/test/resources/unit-test.xml
@@ -7,6 +7,6 @@
   <!-- メインの設定 -->
   <import file="web-component-configuration.xml"/>
 
-  <!-- テスト用HttpServerにJetty6を定義する -->
-  <component name="httpServerFactory" class="nablarch.fw.web.httpserver.HttpServerFactoryJetty6"/>
+  <!-- テスト用HttpServerにJetty12を定義する -->
+  <component name="httpServerFactory" class="nablarch.fw.web.httpserver.HttpServerFactoryJetty12"/>
 </component-configuration>


### PR DESCRIPTION
マイグレーションガイドに従って、proman-projectのバージョンアップを行いました。
6系の最新版6u2（6-NEXT-SNAPSHOT）でREADME通り動作できる状態にしました。