### PR TITLE
proman-projectのNablarchをv6に上げる（batch）

### DIFF
--- a/サンプルプロジェクト/ソースコード/proman-project/proman-batch/pom.xml
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-batch/pom.xml
@@ -132,6 +132,19 @@
       <artifactId>nablarch-fw-messaging-http</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>jakarta.activation</groupId>
+      <artifactId>jakarta.activation-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
マイグレーションガイドに従って、proman-projectのバージョンアップを行いました。
6系の最新版6u2（6-NEXT-SNAPSHOT）でREADME通り動作できる状態にしました。