### PR TITLE
ポート番号の修正とJava21対応、PostgresDriverのバージョンアップ

### DIFF
--- a/サンプルプロジェクト/ソースコード/climan-project/pom.xml
+++ b/サンプルプロジェクト/ソースコード/climan-project/pom.xml
@@ -23,7 +23,7 @@
     <version.plugins.checkstyle>3.1.0</version.plugins.checkstyle>
     <version.plugins.spotbugs>4.5.0.0</version.plugins.spotbugs>
     <version.spotbugs>4.5.0</version.spotbugs>
-    <postgres.jdbc.driver.version>42.5.0</postgres.jdbc.driver.version>
+    <postgres.jdbc.driver.version>42.7.2</postgres.jdbc.driver.version>
     <nablarch.tools.dir>${project.basedir}/tools</nablarch.tools.dir>
     <!-- gsp-dba-maven-pluginが使用するデータベース設定 -->
     <nablarch.db.jdbcDriver>org.postgresql.Driver</nablarch.db.jdbcDriver>

--- a/サンプルプロジェクト/ソースコード/climan-project/pom.xml
+++ b/サンプルプロジェクト/ソースコード/climan-project/pom.xml
@@ -15,7 +15,7 @@
 
   <properties>
     <!-- ソース及びclassファイルが準拠するJavaのバージョン-->
-    <java.version>17</java.version>
+    <java.version>21</java.version>
 
     <!-- 環境ごとのリソースディレクトリ(プロファイルにより切り替わる) -->
     <!--suppress UnresolvedMavenProperty -->
@@ -544,6 +544,11 @@
         <groupId>org.eclipse.jetty.ee10</groupId>
         <artifactId>jetty-ee10-maven-plugin</artifactId>
         <version>12.0.3</version>
+        <configuration>
+          <httpConnector>
+            <port>9080</port>
+          </httpConnector>
+        </configuration>
       </plugin>      <!-- ================ここから任意で使用するツールの設定================ -->
       <!-- gsp-dba-maven-pluginで自動生成したソースをビルド時に使用するための設定 -->
       <plugin>

--- a/サンプルプロジェクト/ソースコード/proman-project/pom.xml
+++ b/サンプルプロジェクト/ソースコード/proman-project/pom.xml
@@ -24,10 +24,13 @@
   </modules>
 
   <properties>
+    <!-- ソース及びclassファイルが準拠するJavaのバージョン-->
+    <java.version>21</java.version>
+
     <version.plugins.checkstyle>3.1.0</version.plugins.checkstyle>
     <version.plugins.spotbugs>4.5.0.0</version.plugins.spotbugs>
     <version.spotbugs>4.5.0</version.spotbugs>
-    <postgres.jdbc.driver.version>42.5.0</postgres.jdbc.driver.version>
+    <postgres.jdbc.driver.version>42.7.2</postgres.jdbc.driver.version>
     <!--
     toolsディレクトリへのパス。ツールが実行される個別モジュールのディレクトリから見て1つ上（つまりこのディレクトリ）のtoolsを指す。
      -->

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-web/pom.xml
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-web/pom.xml
@@ -236,6 +236,11 @@
         <groupId>org.eclipse.jetty.ee10</groupId>
         <artifactId>jetty-ee10-maven-plugin</artifactId>
         <version>12.0.3</version>
+        <configuration>
+          <httpConnector>
+            <port>9088</port>
+          </httpConnector>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -283,21 +288,6 @@
       <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
-      </plugin>
-
-      <!-- waitt pluginでエラー発生するための暫定回避策 -->
-      <plugin>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-maven-plugin</artifactId>
-        <version>9.4.18.v20190429</version>
-        <configuration>
-          <webAppConfig>
-            <contextPath>/</contextPath>
-          </webAppConfig>
-          <httpConnector>
-            <port>9088</port>
-          </httpConnector>
-        </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
- #160 #161 #165 の対応で、ポート番号がReadmeの記載と異なってしまったため修正しました。
- Java21にバージョンアップしました。（バージョン上げ以外修正なし）
- PostgreSQLのドライバーを6の解説書で案内しているバージョンに揃えました。

上記でcliman-project、proman-project（web,batch）にReadme通り動作すること、単体テストが通ることは確認しました。