### PR TITLE
サンプルプロジェクトの依存関係を見直し

### DIFF
--- a/サンプルプロジェクト/ソースコード/climan-project/pom.xml
+++ b/サンプルプロジェクト/ソースコード/climan-project/pom.xml
@@ -70,7 +70,6 @@
           <groupId>com.nablarch.framework</groupId>
           <artifactId>nablarch-fw-web-hotdeploy</artifactId>
         </dependency>
-        <!-- TODO: プロジェクトで使用するDB製品にあわせたJDBCドライバに修正してください。 -->
         <dependency>
           <groupId>org.postgresql</groupId>
           <artifactId>postgresql</artifactId>
@@ -78,10 +77,9 @@
           <scope>runtime</scope>
         </dependency>
         <dependency>
-          <groupId>commons-dbcp</groupId>
-          <artifactId>commons-dbcp</artifactId>
-          <version>1.4</version>
-          <scope>runtime</scope>
+          <groupId>com.zaxxer</groupId>
+          <artifactId>HikariCP</artifactId>
+          <version>3.3.1</version>
         </dependency>
       </dependencies>
     </profile>

--- a/サンプルプロジェクト/ソースコード/climan-project/src/env/dev/resources/db-for-webui_dev.xml
+++ b/サンプルプロジェクト/ソースコード/climan-project/src/env/dev/resources/db-for-webui_dev.xml
@@ -10,7 +10,6 @@
   <import file="nablarch/core/db/connection-factory-datasource.xml"/>
 
   <!-- データソース設定 -->
-  <!-- TODO: プロジェクトで使用するDB製品にあわせた定義を設定してください。 -->
   <component name="dataSource"
              class="org.apache.commons.dbcp.BasicDataSource">
     <property name="driverClassName" value="${nablarch.db.jdbcDriver}"/>

--- a/サンプルプロジェクト/ソースコード/climan-project/src/env/dev/resources/db-for-webui_dev.xml
+++ b/サンプルプロジェクト/ソースコード/climan-project/src/env/dev/resources/db-for-webui_dev.xml
@@ -11,13 +11,12 @@
 
   <!-- データソース設定 -->
   <component name="dataSource"
-             class="org.apache.commons.dbcp.BasicDataSource">
-    <property name="driverClassName" value="${nablarch.db.jdbcDriver}"/>
-    <property name="url"             value="${nablarch.db.url}"/>
+             class="com.zaxxer.hikari.HikariDataSource" autowireType="None">
+    <property name="jdbcUrl"         value="${nablarch.db.url}"/>
     <property name="username"        value="${nablarch.db.user}"/>
     <property name="password"        value="${nablarch.db.password}"/>
-    <property name="maxActive"       value="${nablarch.db.maxPoolSize}"/>
-    <property name="initialSize"     value="${nablarch.db.initialPoolSize}"/>
-   </component>
+    <property name="maximumPoolSize" value="${nablarch.db.maxPoolSize}"/>
+    <property name="minimumIdle"     value="${nablarch.db.initialPoolSize}"/>
+  </component>
 
 </component-configuration>

--- a/サンプルプロジェクト/ソースコード/climan-project/src/env/dev/resources/env.config
+++ b/サンプルプロジェクト/ソースコード/climan-project/src/env/dev/resources/env.config
@@ -5,23 +5,18 @@
 nablarch.connectionFactory.jndiResourceName=dummy
 
 # JDBC接続ドライバクラス(DataSourceを直接使用する際の項目)
-# (TODO: 開発環境で使用するDBに合わせて変更する。)
 nablarch.db.jdbcDriver=org.postgresql.Driver
 
 # JDBC接続URL(DataSourceを直接使用する際の項目)
-# (TODO: 開発環境用の接続先に変更する。H2の接続URLは、データファイルの所在とユーザ名で決定される。変更する際は、理解したうえで変更すること)
 nablarch.db.url=jdbc:postgresql://localhost:5432/postgres
 
 # DB接続ユーザ名(DataSourceを直接使用する際の項目)
-# (TODO: 開発環境用のユーザ名に変更する)
 nablarch.db.user=client
 
 # DB接続パスワード(DataSourceを直接使用する際の項目)
-# (TODO: 開発環境用のパスワードに変更する)
 nablarch.db.password=password
 
 # DBスキーマ名(DataSourceを直接使用する際の項目)
-# (TODO: 自動テスト用のスキーマ名に変更する。H2使用時は「PUBLIC」を設定すること)
 nablarch.db.schema=client
 
 # 最大プールサイズ(DataSourceを直接使用する際の項目)

--- a/サンプルプロジェクト/ソースコード/climan-project/src/env/dev/resources/handler_dev.xml
+++ b/サンプルプロジェクト/ソースコード/climan-project/src/env/dev/resources/handler_dev.xml
@@ -27,20 +27,6 @@
 
         <component-ref name="transactionManagementHandler"/>
 
-        <!-- ホットデプロイハンドラ -->
-        <!--　TODO:開発環境で本ハンドラを使用する場合、各PJでホットデプロイ対象となるパッケージを指定すること
-        <component class="nablarch.fw.hotdeploy.HotDeployHandler">
-          <property name="targetPackages">
-            <list>
-              <value>com.nablarch.example.app.web.action</value>
-              <value>com.nablarch.example.app.web.form</value>
-              <value>com.nablarch.example.app.web.core.validation.validator</value>
-              <value>com.nablarch.example.app.web.util</value>
-            </list>
-          </property>
-        </component>
-        -->
-
         <component-ref name="packageMapping"/>
       </list>
     </property>

--- a/サンプルプロジェクト/ソースコード/climan-project/src/env/prod/resources/env.config
+++ b/サンプルプロジェクト/ソースコード/climan-project/src/env/prod/resources/env.config
@@ -1,5 +1,4 @@
 # JNDIでDataSourceを取得する際のリソース名
-# (TODO: APサーバに登録したデータソースのJNDIリソース名に変更する)
 nablarch.connectionFactory.jndiResourceName=java:comp/env/datasource
 
 # コードの初期ロード設定

--- a/サンプルプロジェクト/ソースコード/proman-project/pom.xml
+++ b/サンプルプロジェクト/ソースコード/proman-project/pom.xml
@@ -75,12 +75,7 @@
         <artifactId>postgresql</artifactId>
         <version>${postgres.jdbc.driver.version}</version>
       </dependency>
-      <!--
-       Connection Pool
-       Commons DBCP2はJava8でしか動作しない
-       > DBCP 2.6.0 compiles and runs under Java 8 only (JDBC 4.2)
-       HikariCPの3系はJava8から11まで
-       -->
+      <!-- Connection Pool -->
       <dependency>
         <groupId>com.zaxxer</groupId>
         <artifactId>HikariCP</artifactId>

--- a/サンプルプロジェクト/ソースコード/proman-project/pom.xml
+++ b/サンプルプロジェクト/ソースコード/proman-project/pom.xml
@@ -81,6 +81,7 @@
         <artifactId>HikariCP</artifactId>
         <version>3.3.1</version>
       </dependency>
+      <!-- JUnit -->
       <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
@@ -89,9 +90,8 @@
         <scope>import</scope>
       </dependency>
     </dependencies>
-
-
   </dependencyManagement>
+
   <build>
     <pluginManagement>
       <plugins>

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-batch/pom.xml
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-batch/pom.xml
@@ -134,14 +134,6 @@
     </dependency>
 
     <dependency>
-      <groupId>jakarta.activation</groupId>
-      <artifactId>jakarta.activation-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>jakarta.xml.bind</groupId>
-      <artifactId>jakarta.xml.bind-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>jakarta.annotation</groupId>
       <artifactId>jakarta.annotation-api</artifactId>
     </dependency>

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-batch/src/env/demo/resources/env.config
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-batch/src/env/demo/resources/env.config
@@ -3,23 +3,18 @@
 nablarch.connectionFactory.jndiResourceName=
 
 # JDBC接続ドライバクラス(DataSourceを直接使用する際の項目)
-# (TODO: 開発環境で使用するDBに合わせて変更する。)
 nablarch.db.jdbcDriver=org.postgresql.Driver
 
 # JDBC接続URL(DataSourceを直接使用する際の項目)
-# (TODO: 開発環境用の接続先に変更する。H2の接続URLは、データファイルの所在とユーザ名で決定される。変更する際は、理解したうえで変更すること)
 nablarch.db.url=jdbc:postgresql://postgres:5432/postgres
 
 # DB接続ユーザ名(DataSourceを直接使用する際の項目)
-# (TODO: 開発環境用のユーザ名に変更する)
 nablarch.db.user=postgres
 
 # DB接続パスワード(DataSourceを直接使用する際の項目)
-# (TODO: 開発環境用のパスワードに変更する)
 nablarch.db.password=password
 
 # DBスキーマ名(DataSourceを直接使用する際の項目)
-# (TODO: 自動テスト用のスキーマ名に変更する。H2使用時は「PUBLIC」を設定すること)
 nablarch.db.schema=public
 
 # 最大プールサイズ(DataSourceを直接使用する際の項目)
@@ -33,15 +28,12 @@ nablarch.db.initialPoolSize=2
 nablarch.codeCache.loadOnStartUp=false
 
 # フォーマット定義ファイルの格納ディレクトリ
-# TODO: PJのファイルパスに変更する
 nablarch.filePathSetting.basePathSettings.format=file:./src/main/format
 
 # 出力ファイルの出力先ディレクトリ
-# TODO: PJのファイルパスに変更する
 nablarch.filePathSetting.basePathSettings.output=file:./work/output
 
 # バッチ入力ファイルの格納ディレクトリ
-# TODO: PJのファイルパスに変更する
 nablarch.filePathSetting.basePathSettings.input=file:./work/input
 
 # csv_outputの出力先ディレクトリ

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-batch/src/env/dev/resources/env.config
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-batch/src/env/dev/resources/env.config
@@ -3,23 +3,18 @@
 nablarch.connectionFactory.jndiResourceName=
 
 # JDBC接続ドライバクラス(DataSourceを直接使用する際の項目)
-# (TODO: 開発環境で使用するDBに合わせて変更する。)
 nablarch.db.jdbcDriver=org.postgresql.Driver
 
 # JDBC接続URL(DataSourceを直接使用する際の項目)
-# (TODO: 開発環境用の接続先に変更する。H2の接続URLは、データファイルの所在とユーザ名で決定される。変更する際は、理解したうえで変更すること)
 nablarch.db.url=jdbc:postgresql://localhost:5432/postgres
 
 # DB接続ユーザ名(DataSourceを直接使用する際の項目)
-# (TODO: 開発環境用のユーザ名に変更する)
 nablarch.db.user=postgres
 
 # DB接続パスワード(DataSourceを直接使用する際の項目)
-# (TODO: 開発環境用のパスワードに変更する)
 nablarch.db.password=password
 
 # DBスキーマ名(DataSourceを直接使用する際の項目)
-# (TODO: 自動テスト用のスキーマ名に変更する。H2使用時は「PUBLIC」を設定すること)
 nablarch.db.schema=public
 
 # 最大プールサイズ(DataSourceを直接使用する際の項目)
@@ -33,15 +28,12 @@ nablarch.db.initialPoolSize=2
 nablarch.codeCache.loadOnStartUp=false
 
 # フォーマット定義ファイルの格納ディレクトリ
-# TODO: PJのファイルパスに変更する
 nablarch.filePathSetting.basePathSettings.format=file:./src/main/format
 
 # 出力ファイルの出力先ディレクトリ
-# TODO: PJのファイルパスに変更する
 nablarch.filePathSetting.basePathSettings.output=file:./work/output
 
 # バッチ入力ファイルの格納ディレクトリ
-# TODO: PJのファイルパスに変更する
 nablarch.filePathSetting.basePathSettings.input=file:./work/input
 
 # csv_outputの出力先ディレクトリ

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-batch/src/env/prod/resources/env.config
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-batch/src/env/prod/resources/env.config
@@ -2,19 +2,15 @@
 nablarch.connectionFactory.jndiResourceName=
 
 # JDBC接続ドライバクラス(DataSourceを直接使用する際の項目)
-#(TODO: 本番環境で使用するDBに合わせて変更する)
 nablarch.db.jdbcDriver=org.h2.Driver
 
 # JDBC接続URL(DataSourceを直接使用する際の項目)
-# (TODO: 本番環境用の接続先に変更する。H2の接続URLは、データファイルの所在とユーザ名で決定される。変更する際は、理解したうえで変更すること)
 nablarch.db.url=jdbc:h2:./h2/db/SAMPLE
 
 # DB接続ユーザ名(DataSourceを直接使用する際の項目)
-# (TODO: 本番環境用のユーザ名に変更する)
 nablarch.db.user=SAMPLE
 
 # DB接続パスワード(DataSourceを直接使用する際の項目)
-# (TODO: 本番環境用のパスワードに変更する)
 nablarch.db.password=SAMPLE
 
 # 最大プールサイズ(DataSourceを直接使用する際の項目)
@@ -28,15 +24,12 @@ nablarch.db.initialPoolSize=2
 nablarch.codeCache.loadOnStartUp=false
 
 # フォーマット定義ファイルの格納ディレクトリ
-# TODO: PJのファイルパスに変更する
 nablarch.filePathSetting.basePathSettings.format=file:/var/nablarch/format
 
 # 出力ファイルの出力先ディレクトリ
-# TODO: PJのファイルパスに変更する
 nablarch.filePathSetting.basePathSettings.output=file:/var/nablarch/output
 
 # バッチ入力ファイルの格納ディレクトリ
-# TODO: PJのファイルパスに変更する
 nablarch.filePathSetting.basePathSettings.input=file:/var/nablarch/input
 
 

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-batch/src/main/resources/common.config
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-batch/src/main/resources/common.config
@@ -22,47 +22,36 @@ nablarch.statementFactory.fetchSize=50
 nablarch.statementFactory.queryTimeout=600
 
 # バッチ実行時のスレッド数
-# TODO: 性能要件にあわせて変更する
 nablarch.multiThreadExecutionHandler.threadCount=1
 
 # コミット間隔
-# TODO: 性能要件にあわせて変更する
 nablarch.loopHandler.commitInterval=1
 
 # データリードハンドラの読み込み回数上限値
-# TODO: 性能要件にあわせて変更する
 nablarch.dataReadHandler.maxCount=0
 
 # メール送信バッチの監視間隔(msec)
-# TODO: 性能要件にあわせて変更する
 nablarch.processResidentHandler.dataWatchInterval=1000
 
 # テーブルをキューとして使ったメッセージングの監視間隔
-# TODO: 性能要件にあわせて変更する
 nablarch.requestThreadLoopHandler.serviceUnavailabilityRetryInterval=1
 
 # コミットログの出力間隔
-# TODO: 性能要件にあわせて変更する
 nablarch.commitLogger.interval=500
 
 # プロセス停止フラグ確認間隔
-# TODO: 性能要件にあわせて変更する
 nablarch.processStopHandler.checkInterval=100
 
 # 最長リトライ時間(msec)
-# TODO: 性能要件にあわせて変更する
 nablarch.retryHandler.maxRetryTime=300000
 
 # リトライ上限時間(msec)
-# TODO: 性能要件にあわせて変更する
 nablarch.retryHandler.retryCount=10
 
 # リトライ間隔(msec)
-# TODO: 性能要件にあわせて変更する
 nablarch.retryHandler.retryIntervals=5000
 
 # リトライ時のデータリーダ破棄フラグ
-# TODO: 性能要件にあわせて変更する
 nablarch.retryHandler.destroyReader=true
 
 # トランザクション分離レベル
@@ -91,15 +80,12 @@ nablarch.mailRequestConfig.maxAttachedFileSize=2097152
 nablarch.mailConfig.mailRequestSbnId=9999
 
 # メール送信成功時のメッセージID
-# (TODO PJのID体系に併せて設定値を変更)
 nablarch.mailConfig.sendSuccessMessageId=mail.sendSuccess
 
 # メール送信失敗時のメッセージID
-# (TODO PJのID体系に併せて設定値を変更)
 nablarch.mailConfig.sendFailureCode=mail.sendFailure
 
 # メール送信要求件数出力時のメッセージID
-# (TODO PJのID体系に併せて設定値を変更)
 nablarch.mailConfig.mailRequestCountMessageId=mail.requestCount
 
 # 接続タイムアウト値

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-batch/src/main/resources/data-source.xml
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-batch/src/main/resources/data-source.xml
@@ -5,11 +5,9 @@
         xsi:schemaLocation="http://tis.co.jp/nablarch/component-configuration https://nablarch.github.io/schema/component-configuration.xsd">
 
   <!-- ダイアレクト設定 -->
-  <!-- TODO:使用するDBに合わせてダイアレクトを設定すること -->
   <component name="dialect" class="nablarch.core.db.dialect.PostgreSQLDialect" />
 
   <!-- データソース設定 -->
-  <!-- TODO: プロジェクトで使用するDB製品にあわせた定義を設定してください。 -->
   <component name="dataSource"
              class="com.zaxxer.hikari.HikariDataSource" autowireType="None">
     <property name="jdbcUrl"         value="${nablarch.db.url}"/>

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-batch/src/test/resources/unit-test.xml
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-batch/src/test/resources/unit-test.xml
@@ -7,11 +7,6 @@
 
   <import file="batch-boot.xml"/>
 
-  <!-- TODO: 使用するDBに合せて設定してください。 -->
-  <!-- Oracle用の設定 -->
-  <!--
-    <import file="nablarch/test/test-db-info-oracle.xml"/>
-  -->
   <!-- 汎用のDB設定 -->
   <component name="dbInfo" class="nablarch.test.core.db.GenericJdbcDbInfo">
     <property name="dataSource" ref="dataSource"/>

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-common/pom.xml
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-common/pom.xml
@@ -42,39 +42,13 @@
       <groupId>com.nablarch.framework</groupId>
       <artifactId>nablarch-common-code-jdbc</artifactId>
     </dependency>
-    <dependency>
-      <groupId>com.nablarch.framework</groupId>
-      <artifactId>nablarch-common-date</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.nablarch.framework</groupId>
-      <artifactId>nablarch-common-idgenerator-jdbc</artifactId>
-    </dependency>
 
     <dependency>
       <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator</artifactId>
       <version>8.0.0.Final</version>
     </dependency>
-    <dependency>
-      <groupId>jakarta.el</groupId>
-      <artifactId>jakarta.el-api</artifactId>
-    </dependency>
 
-    <dependency>
-      <groupId>com.nablarch.configuration</groupId>
-      <artifactId>nablarch-main-default-configuration</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>jakarta.activation</groupId>
-      <artifactId>jakarta.activation-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>jakarta.xml.bind</groupId>
-      <artifactId>jakarta.xml.bind-api</artifactId>
-    </dependency>
     <dependency>
       <groupId>jakarta.annotation</groupId>
       <artifactId>jakarta.annotation-api</artifactId>

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-web/pom.xml
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-web/pom.xml
@@ -63,10 +63,6 @@
           <groupId>com.zaxxer</groupId>
           <artifactId>HikariCP</artifactId>
         </dependency>
-        <dependency>
-          <groupId>jakarta.servlet</groupId>
-          <artifactId>jakarta.servlet-api</artifactId>
-        </dependency>
       </dependencies>
     </profile>
 
@@ -103,12 +99,6 @@
     <dependency>
       <groupId>com.nablarch.profile</groupId>
       <artifactId>nablarch-web</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.glassfish.web</groupId>
-          <artifactId>jakarta.servlet.jsp.jstl</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>
@@ -120,12 +110,6 @@
       <groupId>com.nablarch.framework</groupId>
       <artifactId>nablarch-testing</artifactId>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.eclipse.jdt.core.compiler</groupId>
-          <artifactId>ecj</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.nablarch.framework</groupId>
@@ -135,12 +119,6 @@
     <dependency>
       <groupId>com.nablarch.configuration</groupId>
       <artifactId>nablarch-testing-default-configuration</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.nablarch.dev</groupId>
-      <artifactId>nablarch-test-support</artifactId>
-      <version>2.0.0</version>
       <scope>test</scope>
     </dependency>
 
@@ -169,10 +147,13 @@
       <artifactId>jakarta.servlet.jsp-api</artifactId>
       <scope>provided</scope>
     </dependency>
-
     <dependency>
       <groupId>jakarta.servlet.jsp.jstl</groupId>
       <artifactId>jakarta.servlet.jsp.jstl-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
     </dependency>
 
     <dependency>
@@ -197,19 +178,6 @@
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>jakarta.activation</groupId>
-      <artifactId>jakarta.activation-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>jakarta.xml.bind</groupId>
-      <artifactId>jakarta.xml.bind-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>jakarta.annotation</groupId>
-      <artifactId>jakarta.annotation-api</artifactId>
     </dependency>
   </dependencies>
 

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/env/demo/resources/db-for-webui_dev.xml
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/env/demo/resources/db-for-webui_dev.xml
@@ -10,7 +10,6 @@
   <import file="nablarch/core/db/connection-factory-datasource.xml"/>
 
   <!-- データソース設定 -->
-  <!-- TODO: プロジェクトで使用するDB製品にあわせた定義を設定してください。 -->
   <component name="dataSource"
              class="com.zaxxer.hikari.HikariDataSource" autowireType="None">
     <property name="jdbcUrl"         value="${nablarch.db.url}"/>

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/env/demo/resources/env.config
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/env/demo/resources/env.config
@@ -5,23 +5,18 @@
 nablarch.connectionFactory.jndiResourceName=dummy
 
 # JDBC接続ドライバクラス(DataSourceを直接使用する際の項目)
-# (TODO: 開発環境で使用するDBに合わせて変更する。)
 nablarch.db.jdbcDriver=org.postgresql.Driver
 
 # JDBC接続URL(DataSourceを直接使用する際の項目)
-# (TODO: 開発環境用の接続先に変更する。H2の接続URLは、データファイルの所在とユーザ名で決定される。変更する際は、理解したうえで変更すること)
 nablarch.db.url=jdbc:postgresql://postgres:5432/postgres
 
 # DB接続ユーザ名(DataSourceを直接使用する際の項目)
-# (TODO: 開発環境用のユーザ名に変更する)
 nablarch.db.user=postgres
 
 # DB接続パスワード(DataSourceを直接使用する際の項目)
-# (TODO: 開発環境用のパスワードに変更する)
 nablarch.db.password=password
 
 # DBスキーマ名(DataSourceを直接使用する際の項目)
-# (TODO: 自動テスト用のスキーマ名に変更する。H2使用時は「PUBLIC」を設定すること)
 nablarch.db.schema=public
 
 # 最大プールサイズ(DataSourceを直接使用する際の項目)
@@ -41,11 +36,9 @@ nablarch.codeCache.loadOnStartUp=false
 nablarch.routesMapping.checkInterval=5
 
 # フォーマット定義ファイルの格納ディレクトリ
-# (TODO: PJのファイルパスに変更する)
 nablarch.filePathSetting.basePathSettings.format=file:./src/main/format
 
 # 出力ファイルの出力先ディレクトリ
-# (TODO: PJのファイルパスに変更する)
 nablarch.filePathSetting.basePathSettings.output=file:./work/output
 
 # アップロードファイルの自動クリーニングを行うかどうか
@@ -53,5 +46,4 @@ nablarch.filePathSetting.basePathSettings.output=file:./work/output
 nablarch.uploadSettings.autoCleaning=false
 
 # アップロードファイル一時ディレクトリ
-# (TODO: PJのファイルパスに変更する)
 nablarch.filePathSetting.basePathSettings.uploadFileTmpDir=file:./work/tmp

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/env/dev/resources/db-for-webui_dev.xml
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/env/dev/resources/db-for-webui_dev.xml
@@ -10,7 +10,6 @@
   <import file="nablarch/core/db/connection-factory-datasource.xml"/>
 
   <!-- データソース設定 -->
-  <!-- TODO: プロジェクトで使用するDB製品にあわせた定義を設定してください。 -->
   <component name="dataSource"
              class="com.zaxxer.hikari.HikariDataSource" autowireType="None">
     <property name="jdbcUrl"         value="${nablarch.db.url}"/>

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/env/dev/resources/env.config
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/env/dev/resources/env.config
@@ -5,23 +5,18 @@
 nablarch.connectionFactory.jndiResourceName=dummy
 
 # JDBC接続ドライバクラス(DataSourceを直接使用する際の項目)
-# (TODO: 開発環境で使用するDBに合わせて変更する。)
 nablarch.db.jdbcDriver=org.postgresql.Driver
 
 # JDBC接続URL(DataSourceを直接使用する際の項目)
-# (TODO: 開発環境用の接続先に変更する。H2の接続URLは、データファイルの所在とユーザ名で決定される。変更する際は、理解したうえで変更すること)
 nablarch.db.url=jdbc:postgresql://localhost:5432/postgres
 
 # DB接続ユーザ名(DataSourceを直接使用する際の項目)
-# (TODO: 開発環境用のユーザ名に変更する)
 nablarch.db.user=postgres
 
 # DB接続パスワード(DataSourceを直接使用する際の項目)
-# (TODO: 開発環境用のパスワードに変更する)
 nablarch.db.password=password
 
 # DBスキーマ名(DataSourceを直接使用する際の項目)
-# (TODO: 自動テスト用のスキーマ名に変更する。H2使用時は「PUBLIC」を設定すること)
 nablarch.db.schema=public
 
 # 最大プールサイズ(DataSourceを直接使用する際の項目)
@@ -41,11 +36,9 @@ nablarch.codeCache.loadOnStartUp=false
 nablarch.routesMapping.checkInterval=5
 
 # フォーマット定義ファイルの格納ディレクトリ
-# (TODO: PJのファイルパスに変更する)
 nablarch.filePathSetting.basePathSettings.format=file:./src/main/format
 
 # 出力ファイルの出力先ディレクトリ
-# (TODO: PJのファイルパスに変更する)
 nablarch.filePathSetting.basePathSettings.output=file:./work/output
 
 # アップロードファイルの自動クリーニングを行うかどうか
@@ -53,5 +46,4 @@ nablarch.filePathSetting.basePathSettings.output=file:./work/output
 nablarch.uploadSettings.autoCleaning=false
 
 # アップロードファイル一時ディレクトリ
-# (TODO: PJのファイルパスに変更する)
 nablarch.filePathSetting.basePathSettings.uploadFileTmpDir=file:./work/tmp

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/env/prod/resources/env.config
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/env/prod/resources/env.config
@@ -1,5 +1,4 @@
 # JNDIでDataSourceを取得する際のリソース名
-# (TODO: APサーバに登録したデータソースのJNDIリソース名に変更する)
 nablarch.connectionFactory.jndiResourceName=java:comp/env/datasource
 
 # コードの初期ロード設定
@@ -13,11 +12,9 @@ nablarch.codeCache.loadOnStartUp=true
 nablarch.routesMapping.checkInterval=0
 
 # フォーマット定義ファイルの格納ディレクトリ
-# (TODO: PJのファイルパスに変更する)
 nablarch.filePathSetting.basePathSettings.format=file:/var/nablarch/format
 
 # 出力ファイルの出力先ディレクトリ
-# (TODO: PJのファイルパスに変更する)
 nablarch.filePathSetting.basePathSettings.output=file:/var/nablarch/output
 
 # アップロードファイルの自動クリーニングを行うかどうか
@@ -25,5 +22,4 @@ nablarch.filePathSetting.basePathSettings.output=file:/var/nablarch/output
 nablarch.uploadSettings.autoCleaning=true
 
 # アップロードファイル一時ディレクトリ
-# (TODO: PJのファイルパスに変更する)
 nablarch.filePathSetting.basePathSettings.uploadFileTmpDir=file:/var/tmp/upload

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/resources/web-component-configuration.xml
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/resources/web-component-configuration.xml
@@ -82,19 +82,12 @@
 
   <!-- セッションストア機能 -->
   <import file="nablarch/webui/session-store.xml"/>
-  <!-- TODO: アプリケーションサーバが冗長化されている場合は、HIDDENストアの暗号化に使用するコンポーネントのプロパティに明示的に暗号化/復号のキーを設定する。-->
-  <!--
-  <component name="hiddenStoreEncryptor" class="nablarch.common.encryption.AesEncryptor">
-    <property name="key" value="1234567890123456" />
-    <property name="iv" value="6543210987654321" />
-  </component>
-  -->
+
   <import file="com/nablarch/example/proman/web/webui/session-store.xml"/>
 
   <component name="httpErrorHandler" class="nablarch.fw.web.handler.HttpErrorHandler">
     <property name="defaultPages">
       <map>
-        <!-- TODO: 適切なエラー画面作成して設定してください。設定の際は、あわせてweb.xmlも修正してください -->
         <entry key="4.." value="/WEB-INF/view/errorPages/USER_ERROR.jsp"/>
         <entry key="403" value="/WEB-INF/view/errorPages/PERMISSION-ERROR.jsp"/>
         <entry key="404" value="/WEB-INF/view/errorPages/PAGE_NOT_FOUND_ERROR.jsp"/>
@@ -106,7 +99,6 @@
   </component>
 
   <!-- ダイアレクト設定 -->
-  <!-- TODO:使用するDBに合わせてダイアレクトを設定すること -->
   <component name="dialect" class="nablarch.core.db.dialect.PostgreSQLDialect"/>
 
   <import file="com/nablarch/example/proman/web/webui/threadcontext-for-webui.xml"/>


### PR DESCRIPTION
以下の点について変更しました。

- Nablarch利用時に必要な依存関係を見直し、不要な依存関係は削除
- climan-projectだけコネクションプールにApache Commons DBCPを使用していたため、他と合わせてHikariCPに変更
- 散見された不要なコメント（ブランクプロジェクトに元々入っているTODOコメントなど）を削除
