### PR TITLE
Java 21対応のため静的解析ツールをバージョンアップ

### DIFF
--- a/サンプルプロジェクト/ソースコード/climan-project/pom.xml
+++ b/サンプルプロジェクト/ソースコード/climan-project/pom.xml
@@ -20,11 +20,17 @@
     <!-- 環境ごとのリソースディレクトリ(プロファイルにより切り替わる) -->
     <!--suppress UnresolvedMavenProperty -->
     <env.resources>${project.basedir}/src/env/${env.dir}/resources</env.resources>
-    <version.plugins.checkstyle>3.1.0</version.plugins.checkstyle>
-    <version.plugins.spotbugs>4.5.0.0</version.plugins.spotbugs>
-    <version.spotbugs>4.5.0</version.spotbugs>
+
+    <version.plugins.checkstyle>3.4.0</version.plugins.checkstyle>
+    <version.checkstyle>10.17.0</version.checkstyle>
+    <version.plugins.spotbugs>4.8.6.2</version.plugins.spotbugs>
+    <version.spotbugs>4.8.6</version.spotbugs>
+    <version.plugins.findsecbugs>1.13.0</version.plugins.findsecbugs>
+    <version.plugins.unpublished.api.checker>5-NEXT-SNAPSHOT</version.plugins.unpublished.api.checker>
+    
     <postgres.jdbc.driver.version>42.7.2</postgres.jdbc.driver.version>
     <nablarch.tools.dir>${project.basedir}/tools</nablarch.tools.dir>
+    
     <!-- gsp-dba-maven-pluginが使用するデータベース設定 -->
     <nablarch.db.jdbcDriver>org.postgresql.Driver</nablarch.db.jdbcDriver>
     <nablarch.db.url>jdbc:postgresql://localhost:5432/postgres</nablarch.db.url>
@@ -487,7 +493,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>8.29</version>
+            <version>${version.checkstyle}</version>
           </dependency>
         </dependencies>
         <configuration>
@@ -521,12 +527,12 @@
             <plugin>
               <groupId>com.nablarch.framework</groupId>
               <artifactId>nablarch-unpublished-api-checker</artifactId>
-              <version>1.0.0</version>
+              <version>${version.plugins.unpublished.api.checker}</version>
             </plugin>
             <plugin>
               <groupId>com.h3xstream.findsecbugs</groupId>
               <artifactId>findsecbugs-plugin</artifactId>
-              <version>1.11.0</version>
+              <version>${version.plugins.findsecbugs}</version>
             </plugin>
           </plugins>
         </configuration>

--- a/サンプルプロジェクト/ソースコード/proman-project/pom.xml
+++ b/サンプルプロジェクト/ソースコード/proman-project/pom.xml
@@ -26,9 +26,13 @@
     <!-- ソース及びclassファイルが準拠するJavaのバージョン-->
     <java.version>21</java.version>
 
-    <version.plugins.checkstyle>3.1.0</version.plugins.checkstyle>
-    <version.plugins.spotbugs>4.5.0.0</version.plugins.spotbugs>
-    <version.spotbugs>4.5.0</version.spotbugs>
+    <version.plugins.checkstyle>3.4.0</version.plugins.checkstyle>
+    <version.checkstyle>10.17.0</version.checkstyle>
+    <version.plugins.spotbugs>4.8.6.2</version.plugins.spotbugs>
+    <version.spotbugs>4.8.6</version.spotbugs>
+    <version.plugins.findsecbugs>1.13.0</version.plugins.findsecbugs>
+    <version.plugins.unpublished.api.checker>5-NEXT-SNAPSHOT</version.plugins.unpublished.api.checker>
+    <version.archunit>1.3.0</version.archunit>
     <postgres.jdbc.driver.version>42.7.2</postgres.jdbc.driver.version>
     <!--
     toolsディレクトリへのパス。ツールが実行される個別モジュールのディレクトリから見て1つ上（つまりこのディレクトリ）のtoolsを指す。
@@ -88,6 +92,12 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>com.tngtech.archunit</groupId>
+        <artifactId>archunit-junit5</artifactId>
+        <version>${version.archunit}</version>
+      </dependency>
+
     </dependencies>
   </dependencyManagement>
 
@@ -112,7 +122,7 @@
             <dependency>
               <groupId>com.puppycrawl.tools</groupId>
               <artifactId>checkstyle</artifactId>
-              <version>8.29</version>
+              <version>${version.checkstyle}</version>
             </dependency>
           </dependencies>
           <configuration>
@@ -146,12 +156,12 @@
               <plugin>
                 <groupId>com.nablarch.framework</groupId>
                 <artifactId>nablarch-unpublished-api-checker</artifactId>
-                <version>1.0.0</version>
+                <version>${version.plugins.unpublished.api.checker}</version>
               </plugin>
               <plugin>
                 <groupId>com.h3xstream.findsecbugs</groupId>
                 <artifactId>findsecbugs-plugin</artifactId>
-                <version>1.11.0</version>
+                <version>${version.plugins.findsecbugs}</version>
               </plugin>
             </plugins>
           </configuration>

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-batch/pom.xml
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-batch/pom.xml
@@ -109,7 +109,6 @@
     <dependency>
       <groupId>com.tngtech.archunit</groupId>
       <artifactId>archunit-junit5</artifactId>
-      <version>1.3.0</version>
       <scope>test</scope>
     </dependency>
 

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-web/pom.xml
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-web/pom.xml
@@ -183,7 +183,6 @@
     <dependency>
       <groupId>com.tngtech.archunit</groupId>
       <artifactId>archunit-junit5</artifactId>
-      <version>1.3.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/java/com/nablarch/example/proman/web/project/ProjectUpdateForm.java
+++ b/サンプルプロジェクト/ソースコード/proman-project/proman-web/src/main/java/com/nablarch/example/proman/web/project/ProjectUpdateForm.java
@@ -312,7 +312,7 @@ public class ProjectUpdateForm implements Serializable {
     /**
      * 売上高を設定する。
      *
-     * @param sales 設定する売上高
+     * @param salesAmount 設定する売上高
      */
     public void setSalesAmount(String salesAmount) {
         this.salesAmount = salesAmount;


### PR DESCRIPTION
Nablarch 6やJava 21へのバージョンアップに伴い、静的解析ツールのバージョンを最新化しました。

バージョンアップの参考には[Javaスタイルガイド](https://github.com/Fintan-contents/coding-standards/blob/main/java/README.md)をベースとしましたが、Javaスタイルガイドで案内しているバージョンはJava 17を想定していることや、各ツールのバグフィックス等を考慮し、現時点で安定版の最新版へバージョンアップしました。

また、作業中に検出した以下の点についても修正しています。

- ArchUnitのバージョン指定をルートプロジェクトに集約
- CheckStyleでエラーが検出される状態であったため、一部のコードを修正
