### PR TITLE
ArchUnitのユーティリティ削除がドキュメントに反映されていなかったので修正

### DIFF
--- a/Sample_Project/サンプルプロジェクト開発ガイド/PGUT工程/pg/静的解析チェック違反発生時の対応方法.md
+++ b/Sample_Project/サンプルプロジェクト開発ガイド/PGUT工程/pg/静的解析チェック違反発生時の対応方法.md
@@ -65,28 +65,28 @@
 
 テスト対象がクラスの場合とそれ以外の場合で指定方法が異なるので注意してください。
 
-テスト対象がクラス（レイヤーも含む）の場合、以下のように `and()`（または元々 `that()` がなければ `that()`）の引数に `PromanRuleUtil.notType()` を使用して除外設定を行います。
-
-`PromanRuleUtil` は本PJ用に実装されたクラスです。
+テスト対象がクラス（レイヤーも含む）の場合、`doNotBelongToAnyOf`メソッドに特定のクラス名を指定することで、該当クラスおよび該当クラス内に定義されたクラスをテスト対象から除外できます。
 
 ``` java
 @ArchTest
 public static final ArchRule ActionクラスはBatchActionを継承していること =
-        ArchRuleDefinition.classes().that().haveSimpleNameEndingWith("Action")
-        .and(PromanRuleUtil.notType(
-                PromanExampleAction.class       // #12345
-                , PromanExampleService.class))  // #12346
+        ArchRuleDefinition.classes()
+        .that().haveSimpleNameEndingWith("Action")
+        .and().doNotBelongToAnyOf(
+            PromanExampleAction.class,    // #12345
+            PromanServiceAction.class)    // #12346
         .should().beAssignableTo(BatchAction.class);
 ```
 
-テスト対象がクラス内に含まれるもの（フィールドやメソッドなど）の場合、 `areNotDeclaredIn()` を使用して除外設定を行います。
+特定のクラス内で定義されているフィールドやメソッド等を除外する場合は、 `areNotDeclaredIn`メソッドを使用することでテスト対象から除外できます。
 
 ``` java
 @ArchTest
 public static final ArchRule DaoContextを引数にとるメソッドはパッケージプライベートであること =
-        ArchRuleDefinition.methods().that().haveRawParameterTypes(DaoContext.class)
-            .and().areNotDeclaredIn(PromanExamAction.class)  // #1234
-            .should().bePackagePrivate();
+        ArchRuleDefinition.methods()
+        .that().haveRawParameterTypes(DaoContext.class)
+        .and().areNotDeclaredIn(PromanExamAction.class) // #1234
+        .should().bePackagePrivate();
 ```
 
 またいずれの場合も1行に除外したクラスのみを記載し行コメントにRedmineチケット番号を記載します。

--- a/en/Sample_Project/Sample_Project_Development_Guide/PGUT_Phase/pg/Response_method_when_a_static_analysis_check_violation_occurs.md
+++ b/en/Sample_Project/Sample_Project_Development_Guide/PGUT_Phase/pg/Response_method_when_a_static_analysis_check_violation_occurs.md
@@ -65,28 +65,28 @@ Also, the settings in the exclusion configuration file (`archunit_ignore_pattern
 
 Note that the method to specify the test target is different between the case of a class and other cases.
 
-If the test target is a class (including layers), the following `and()` (or `that()` if it doesn't have `that()`) is used to exclude the test target with `PromanRuleUtil.notType()`.
-
-`PromanRuleUtil` is a class implemented for this project.
+If the test target is a class (including layers), by specifying the class name in the `doNotBelongToAnyOf` method, you can exclude the target class and its internally defined classes from being tested.
 
 ``` java
 @ArchTest
-public static final ArchRule actionClassMustInheritFromBatchAction =
-        ArchRuleDefinition.classes().that().haveSimpleNameEndingWith("Action")
-        .and(PromanRuleUtil.notType(
-                PromanExampleAction.class       // #12345
-                , PromanExampleService.class))  // #12346
+public static final ArchRule actionClassMustInheritFromBatchAction. =
+        ArchRuleDefinition.classes()
+        .that().haveSimpleNameEndingWith("Action")
+        .and().doNotBelongToAnyOf(
+            PromanExampleAction.class,    // #12345
+            PromanServiceAction.class)    // #12346
         .should().beAssignableTo(BatchAction.class);
 ```
 
-If the test target is a field or method in a class, the `areNotDeclaredIn()` is used to configure the exclusion.
+To exclude fields, methods, etc. defined within a specific class, you can use the `areNotDeclaredIn` method.
 
 ``` java
 @ArchTest
-public static final ArchRule methodsThatTakeDaoContextAsArgumentMustBePackagePrivate =
-        ArchRuleDefinition.methods().that().haveRawParameterTypes(DaoContext.class)
-            .and().areNotDeclaredIn(PromanExamAction.class)  // #1234
-            .should().bePackagePrivate();
+public static final ArchRule methodsThatTakeDaoContextAsAnArgumentMustBePackagePrivate =
+        ArchRuleDefinition.methods()
+        .that().haveRawParameterTypes(DaoContext.class)
+        .and().areNotDeclaredIn(PromanExamAction.class) // #1234
+        .should().bePackagePrivate();
 ```
 
 And in any case, should write only excluded class in one line and write Redmine ticket number in line comment.


### PR DESCRIPTION
#178 の対応でArchUnit用のユーティリティクラスを削除しているが、ガイドの記載に反映されていなかったため、ガイドを修正しました。

内容については、ほぼスタイルガイドと同様になります。

- [ArchUnit運用ガイドの除外対象設定](https://github.com/Fintan-contents/nablarch-system-development-guide/blob/master/%E3%82%B5%E3%83%B3%E3%83%97%E3%83%AB%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88/%E3%82%B5%E3%83%B3%E3%83%97%E3%83%AB%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E9%96%8B%E7%99%BA%E3%82%AC%E3%82%A4%E3%83%89/PGUT%E5%B7%A5%E7%A8%8B/proman-style-guide/java/staticanalysis/archunit/docs/Ops-Rule.md#%E9%99%A4%E5%A4%96%E5%AF%BE%E8%B1%A1%E3%82%AF%E3%83%A9%E3%82%B9%E3%81%AE%E8%A8%AD%E5%AE%9A%E3%83%86%E3%82%B9%E3%83%88%E3%82%B3%E3%83%BC%E3%83%89%E3%81%AB%E9%99%A4%E5%A4%96%E5%AF%BE%E8%B1%A1%E3%82%92%E8%A8%98%E8%BC%89)
- [ArchUnit運用ガイドの除外対象設定（英語版）](https://github.com/Fintan-contents/nablarch-system-development-guide/blob/develop/en/Sample_Project/Sample_Project_Development_Guide/PGUT_Phase/proman-style-guide/java/staticanalysis/archunit/docs/Ops-Rule.md#configuration-of-the-exclusion-target-class-describe-the-exclusion-target-in-the-test-code)